### PR TITLE
Make MulticoreTSNE optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         "tables>=3.4.2",
         "Cython",
         "cmake",
-        "MulticoreTSNE",
         "matplotlib>=2.2.2",
         "seaborn>=0.8.1",
         "tzlocal",

--- a/src/palantir/preprocess.py
+++ b/src/palantir/preprocess.py
@@ -40,6 +40,6 @@ def log_transform(data, pseudo_count=0.1):
     :return: Log transformed matrix
     """
     if type(data) is sc.AnnData:
-        data.X.data = np.log2(data.X.data + pseudo_count) - np.log2(pseudo_count)
+        data.X = np.log2(data.X + pseudo_count) - np.log2(pseudo_count)
     else:
         return np.log2(data + pseudo_count)

--- a/src/palantir/utils.py
+++ b/src/palantir/utils.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import numpy as np
-from MulticoreTSNE import MulticoreTSNE as TSNE
+from sklearn.manifold import TSNE
+
 import phenograph
 
 from scipy.sparse import csr_matrix, find, issparse
@@ -160,9 +161,17 @@ def run_tsne(data, n_dim=2, perplexity=150, **kwargs):
     :param n_dim: Number of dimensions for tSNE embedding
     :return: tSNE embedding of the data
     """
-    tsne = TSNE(n_components=n_dim, perplexity=perplexity, **kwargs).fit_transform(
-        data.values
-    )
+    try:
+        from MulticoreTSNE import MulticoreTSNE as TSNE
+        
+        print("Using the 'MulticoreTSNE' package by Ulyanov (2017)")
+        tsne = TSNE(n_components=n_dim, perplexity=perplexity, **kwargs).fit_transform(data.values)
+    except ImportError:
+        from sklearn.manifold import TSNE
+
+        print("Could not import 'MulticoreTSNE'. Install for faster runtime. Falling back to scikit-learn.")
+        tsne = TSNE(n_components= n_dim, perplexity= perplexity, **kwargs).fit_transform(data.values)
+    
     tsne = pd.DataFrame(tsne, index=data.index)
     tsne.columns = ["x", "y"]
     return tsne


### PR DESCRIPTION
Fixed bug where some users, especially windows, have trouble installing MulticoreTSNE. 

Thus, we remove it as a dependency and instead make it optional.