### PR TITLE
implement palantir.plot.plot_stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ ____
 
 Release Notes
 -------------
+ ### Version 1.3.2
+ * implemented `palantir.plot.plot_stats` to plot arbitray cell-wise statistics as x-/y-positions.
+ * reduce memory usgae of `palantir.presults.compute_gene_trends`
+ 
  ### Version 1.3.1
  * removed seaborn dependency
 

--- a/src/palantir/config.py
+++ b/src/palantir/config.py
@@ -1,6 +1,4 @@
-import warnings
 import matplotlib
-from matplotlib import font_manager
 
 matplotlib.rcParams["figure.dpi"] = 100
 matplotlib.rcParams["image.cmap"] = "Spectral_r"

--- a/src/palantir/plot.py
+++ b/src/palantir/plot.py
@@ -5,7 +5,6 @@ from copy import copy
 from cycler import Cycler
 import numpy as np
 import pandas as pd
-from itertools import chain
 from sklearn.preprocessing import StandardScaler
 from scipy.stats import gaussian_kde
 import scanpy as sc
@@ -917,7 +916,7 @@ def _process_mask(ad: sc.AnnData, masks_key: str, branch_name: str):
 def prepare_color_vector(
     ad: sc.AnnData,
     color: str,
-    mask: np.ndarray,
+    mask: Optional[np.ndarray] = None,
     layer: Optional[str] = None,
     palette: Optional[Union[str, Sequence[str]]] = None,
     na_color: str = "lightgray",
@@ -931,7 +930,7 @@ def prepare_color_vector(
         The annotated data matrix
     color : str
         The color parameter
-    mask : np.ndarray
+    mask : np.ndarray, optional
         Boolean mask array
     layer : str, optional
         The data layer to use
@@ -950,7 +949,8 @@ def prepare_color_vector(
     color_vector, categorical = _color_vector(
         ad, color, color_source_vector, palette=palette, na_color=na_color
     )
-    color_vector = color_vector[mask]
+    if mask is not None:
+        color_vector = color_vector[mask]
 
     return color_source_vector, color_vector, categorical
 
@@ -989,6 +989,220 @@ def _add_categorical_legend(
         ncol=(1 if len(cats) <= 14 else 2 if len(cats) <= 30 else 3),
         fontsize=legend_fontsize,
     )
+
+
+def plot_stats(
+    ad: sc.AnnData,
+    x: str,
+    y: str,
+    color: str = None,
+    ax: Optional[plt.Axes] = None,
+    na_color: str = "lightgray",
+    color_layer: Optional[str] = None,
+    x_layer: Optional[str] = None,
+    y_layer: Optional[str] = None,
+    branch_name: Optional[str] = None,
+    masks_key: str = "branch_masks",
+    legend_fontsize: Union[int, float, _FontSize, None] = None,
+    legend_fontweight: Union[int, _FontWeight] = "bold",
+    legend_fontoutline: Optional[int] = None,
+    legend_anchor: Tuple[float, float] = (1.1, 0.5),
+    color_bar_bounds: list = [1.1, 0.3, 0.02, 0.4],
+    cmap: Union[Colormap, str, None] = None,
+    palette: Union[str, Sequence[str], Cycler, None] = None,
+    vmax: Union[VBound, Sequence[VBound], None] = None,
+    vmin: Union[VBound, Sequence[VBound], None] = None,
+    vcenter: Union[VBound, Sequence[VBound], None] = None,
+    norm: Union[Normalize, Sequence[Normalize], None] = None,
+    nticks: int = 3,
+    figsize: Tuple[float, float] = (6, 6),
+    **kwargs,
+):
+    """
+    This function visualizes a scatter plot of cells over pseudotime.
+    The y-position indicates either a gene expression
+    or any column from .obs or use a different position_layer, like
+    "MAGIC_imputed_data". The color follows similar rules and behaves like the color
+    parameter in scanpy.pl.embedding, but only accepts a single value instead of a list.
+
+    Parameters
+    ----------
+    ad : AnnData
+        Annotated data matrix of shape n_obs x n_vars. Rows correspond
+        to cells and columns to genes.
+    x : str
+        Similar to color but used for x-position.
+    y : str
+        Similar to color but used for y-position.
+    color : str, optional
+        Defines the color to be used for the plot, similar to the color in
+        scanpy.pl.embedding. If not provided, the default is None.
+    ax : Axes, optional
+        A matplotlib axes object.
+    na_color : str, optional
+        The color to be used for 'NA' values. Default is "lightgray".
+    color_layer : str, optional
+        Specifies the data layer to use for color in the plot.
+        If not provided, the .X layer is used.
+    x_layer : str, optional
+        Specifies the data layer to use for x-position in the plot.
+        If not provided, the .X layer is used.
+    y_layer : str, optional
+        Specifies the data layer to use for y-position in the plot.
+        If not provided, the .X layer is used.
+    branch_name : str, optional
+        Specifies the branch to subset the plot to. The default is None.
+    masks_key : str, optional
+        Key for accessing the branch cell selection masks from obsm of the AnnData object.
+        Default is 'branch_masks'.
+    legend_fontsize : Union[int, float, _FontSize, None], optional
+        Specifies the font size for the legend. Default is None.
+    legend_fontweight : Union[int, _FontWeight], optional
+        Specifies the font weight for the legend. Default is 'bold'.
+    legend_fontoutline : int, optional
+        Specifies the font outline for the legend. Default is None.
+    legend_anchor: Tuple[float, float] = (1.1, 0.5),
+        Defines the position of the legend. The argument will be passed to the
+        bbox_to_anchor parameter of ax.legend() method. The default is (1.1, 0.5).
+    color_bar_bounds : list, optional
+        Specifies the bounds for the color bar. Defaults to [1, 0.4, 0.01, 0.2].
+    cmap : Union[Colormap, str, None]
+        A colormap instance or registered colormap name to color the scatter plot.
+    palette : Union[str, Sequence[str], Cycler, None], optional
+        Colors to use for plotting categorical annotation groups.
+        The palette can be a valid matplotlib.colors.ListedColormap name
+        ('viridis', 'Set2', etc), a cycler.Cycler object, or a sequence of
+        matplotlib colors like ['red', 'blue', 'green'].
+    vmax : float or array-like or None
+        Defines the lower limit of the color scale with values smaller than
+        vmin sharing the same color. It can be a number, percentile string ('pN'),
+        function returning a desired value from the plot values, or None for
+        automatic selection. For multiple plots, a list of vmin can be specified.
+    vmin : float or array-like or None
+        Sets the upper limit of the color scale, with the same format and behavior as vmin.
+    vcenter : float or array-like or None
+        Sets the center of the color scale, useful for diverging colormaps.
+        It follows the same format and rules as vmin and vmax. Example:
+        sc.pl.umap(adata, color='TREM2', vcenter='p50', cmap='RdBu_r').
+    norm : matplotlib.colors.Normalize or None
+        The normalizing object which scales data, typically into the interval [0, 1].
+        If provided, vmax, vmin, and vcenter are ignored.
+    nticks: int, optional
+        The number of ticks to be displayed on both the x and y axes. The matplotlib's
+        Axes.locator_params method is used for setting this property. Default is 3.
+    figsize : Tuple[float, float], optional
+        Width and height of each subplot in inches. Default is (12, 4).
+
+    Returns
+    -------
+    fig, ax : figure and axis elements of the plot.
+
+    Raises
+    ------
+    TypeError
+        If input parameters are not of the expected type.
+    ValueError
+        If input parameters do not have the expected values.
+    """
+
+    if not isinstance(ad, sc.AnnData):
+        raise TypeError("Expected ad to be an instance of sc.AnnData")
+    if branch_name is not None and not isinstance(branch_name, str):
+        raise TypeError("Expected branch_name to be a str or None")
+    if color is not None and not isinstance(color, str):
+        raise TypeError("Expected color to be a str")
+    if ax is not None and not isinstance(ax, plt.Axes):
+        raise TypeError("Expected ax to be a matplotlib Axes instance")
+
+    mask = (
+        _process_mask(ad, masks_key, branch_name)
+        if isinstance(masks_key, str)
+        else masks_key
+    )
+
+    x_pos = _get_color_source_vector(ad, x, layer=x_layer)
+    y_pos = _get_color_source_vector(ad, y, layer=y_layer)
+    if mask is not None:
+        x_pos = x_pos[mask]
+        y_pos = y_pos[mask]
+
+    color_source_vector, color_vector, categorical = prepare_color_vector(
+        ad, color, mask, layer=color_layer, palette=palette, na_color=na_color
+    )
+
+    scatter_kwargs = {
+        "edgecolor": "none",
+        "plotnonfinite": True,
+    }
+    scatter_kwargs.update(kwargs)
+
+    cmap = copy(get_cmap(cmap))
+    cmap.set_bad(na_color)
+
+    na_color = matplotlib.colors.to_hex(na_color, keep_alpha=True)
+
+    if isinstance(vmax, str) or not isinstance(vmax, cabc.Sequence):
+        vmax = [vmax]
+    if isinstance(vmin, str) or not isinstance(vmin, cabc.Sequence):
+        vmin = [vmin]
+    if isinstance(vcenter, str) or not isinstance(vcenter, cabc.Sequence):
+        vcenter = [vcenter]
+    if isinstance(norm, Normalize) or not isinstance(norm, cabc.Sequence):
+        norm = [norm]
+
+    if not categorical and color is not None:
+        vmin_float, vmax_float, vcenter_float, norm_obj = _get_vboundnorm(
+            vmin, vmax, vcenter, norm, 0, color_vector
+        )
+        normalize = check_colornorm(
+            vmin_float,
+            vmax_float,
+            vcenter_float,
+            norm_obj,
+        )
+        scatter_kwargs["norm"] = normalize
+        scatter_kwargs["cmap"] = cmap
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.figure
+    points = ax.scatter(
+        x_pos,
+        y_pos,
+        marker=".",
+        c=color_vector,
+        **scatter_kwargs,
+    )
+    ax.set_xlabel(x)
+    ax.set_ylabel(y)
+    if branch_name is not None:
+        ax.set_title(branch_name)
+    ax.set_zorder(0)
+    ax.set_facecolor("none")
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        ax.locator_params(axis="both", nbins=nticks)
+
+    if categorical or color_vector.dtype == bool:
+        _add_categorical_legend(
+            ax,
+            color_source_vector,
+            palette=_get_palette(ad, color),
+            legend_anchor=legend_anchor,
+            legend_fontweight=legend_fontweight,
+            legend_fontsize=legend_fontsize,
+            legend_fontoutline=None,
+            na_color=na_color,
+            na_in_legend=True,
+        )
+    elif color_bar_bounds is not None and color is not None:
+        cax = ax.inset_axes(color_bar_bounds)
+        cb = plt.colorbar(points, cax=cax)
+        cb.set_label(color)
+
+    return fig, ax
 
 
 def plot_branch(
@@ -1031,8 +1245,8 @@ def plot_branch(
         to cells and columns to genes.
     branch_name : str
         Specifies the branch to plot the trend for.
-    position : str, optional
-        Similar to color but used for y-position. If None, the default is gene.
+    position : str
+        Similar to color but used for y-position.
     color : str, optional
         Defines the color to be used for the plot, similar to the color in
         scanpy.pl.embedding. If not provided, the default is None.
@@ -1101,105 +1315,39 @@ def plot_branch(
     ValueError
         If input parameters do not have the expected values.
     """
-
-    if not isinstance(ad, sc.AnnData):
-        raise TypeError("Expected ad to be an instance of sc.AnnData")
     if not isinstance(branch_name, str):
         raise TypeError("Expected branch_name to be a str")
-    if color is not None and not isinstance(color, str):
-        raise TypeError("Expected color to be a str")
-    if ax is not None and not isinstance(ax, plt.Axes):
-        raise TypeError("Expected ax to be a matplotlib Axes instance")
     if not isinstance(pseudo_time_key, str):
         raise TypeError("Expected pseudo_time_key to be a str")
 
-    mask = (
-        _process_mask(ad, masks_key, branch_name)
-        if isinstance(masks_key, str)
-        else masks_key
-    )
-
-    pseduotimes = ad.obs_vector(pseudo_time_key)
-    pseduotimes = pseduotimes[mask]
-
-    y_pos = _get_color_source_vector(ad, position, layer=position_layer)
-    y_pos = y_pos[mask]
-
-    color_source_vector, color_vector, categorical = prepare_color_vector(
-        ad, color, mask, layer=color_layer, palette=palette, na_color=na_color
-    )
-
-    scatter_kwargs = {
-        "edgecolor": "none",
-        "plotnonfinite": True,
-    }
-    scatter_kwargs.update(kwargs)
-
-    cmap = copy(get_cmap(cmap))
-    cmap.set_bad(na_color)
-
-    na_color = matplotlib.colors.to_hex(na_color, keep_alpha=True)
-
-    if isinstance(vmax, str) or not isinstance(vmax, cabc.Sequence):
-        vmax = [vmax]
-    if isinstance(vmin, str) or not isinstance(vmin, cabc.Sequence):
-        vmin = [vmin]
-    if isinstance(vcenter, str) or not isinstance(vcenter, cabc.Sequence):
-        vcenter = [vcenter]
-    if isinstance(norm, Normalize) or not isinstance(norm, cabc.Sequence):
-        norm = [norm]
-
-    if not categorical and color is not None:
-        vmin_float, vmax_float, vcenter_float, norm_obj = _get_vboundnorm(
-            vmin, vmax, vcenter, norm, 0, color_vector
-        )
-        normalize = check_colornorm(
-            vmin_float,
-            vmax_float,
-            vcenter_float,
-            norm_obj,
-        )
-        scatter_kwargs["norm"] = normalize
-        scatter_kwargs["cmap"] = cmap
-
-    if ax is None:
-        fig, ax = plt.subplots(figsize=figsize)
-    else:
-        fig = ax.figure
-    points = ax.scatter(
-        pseduotimes,
-        y_pos,
-        marker=".",
-        c=color_vector,
-        **scatter_kwargs,
+    fig, ax = plot_stats(
+        ad=ad,
+        x=pseudo_time_key,
+        y=position,
+        color=color,
+        ax=ax,
+        na_color=na_color,
+        color_layer=color_layer,
+        x_layer=None,
+        y_layer=position_layer,
+        branch_name=branch_name,
+        masks_key=masks_key,
+        legend_fontsize=legend_fontsize,
+        legend_fontweight=legend_fontweight,
+        legend_fontoutline=legend_fontoutline,
+        legend_anchor=legend_anchor,
+        color_bar_bounds=color_bar_bounds,
+        cmap=cmap,
+        palette=palette,
+        vmax=vmax,
+        vmin=vmin,
+        vcenter=vcenter,
+        norm=norm,
+        nticks=nticks,
+        figsize=figsize,
+        **kwargs,
     )
     ax.set_xlabel("Pseudotime")
-    ax.set_ylabel(position)
-    ax.set_title(branch_name)
-    ax.set_zorder(0)
-    ax.set_facecolor("none")
-
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=UserWarning)
-        ax.locator_params(axis="both", nbins=nticks)
-
-    if categorical or color_vector.dtype == bool:
-        _add_categorical_legend(
-            ax,
-            color_source_vector,
-            palette=_get_palette(ad, color),
-            legend_anchor=legend_anchor,
-            legend_fontweight=legend_fontweight,
-            legend_fontsize=legend_fontsize,
-            legend_fontoutline=None,
-            na_color=na_color,
-            na_in_legend=True,
-        )
-    elif color_bar_bounds is not None and color is not None:
-        cax = ax.inset_axes(color_bar_bounds)
-        cb = plt.colorbar(points, cax=cax)
-        cb.set_label(color)
-
     return fig, ax
 
 

--- a/src/palantir/utils.py
+++ b/src/palantir/utils.py
@@ -740,7 +740,7 @@ def early_cell(
         )
 
     if not isinstance(celltype, str):
-        raise ValueError(f"celltype should be a string")
+        raise ValueError("celltype should be a string")
 
     if celltype not in ad.obs[celltype_column].values:
         raise ValueError(

--- a/src/palantir/version.py
+++ b/src/palantir/version.py
@@ -1,3 +1,3 @@
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 __author__ = "Palantir development team"
 __author_email__ = "manu.talanki@gmail.com"


### PR DESCRIPTION
@ManuSetty This implements `palantir.plot.plot_stats` which is a more general version of `palantir.plot.plot_branch`. It works very similarly but allows to plot other stats than just pseudo time on the y-axis. Optionally, it allows to subset to a specific branch just like the `palantir.plot.plot_branch` does. Here is an example where we plot the Mellon log-density over the MAGIC imputed EBF1 expression, color by cell type and subsetted to the B-cell branch:
![image](https://github.com/dpeerlab/Palantir/assets/4857068/59793cb4-26aa-48d5-bee1-86c158c8811d)

