### PR TITLE
Refactor run_diffusion_maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,11 @@ ____
 
 Release Notes
 -------------
- ### Version 1.3.2
+ ### Version 1.3.1
  * implemented `palantir.plot.plot_stats` to plot arbitray cell-wise statistics as x-/y-positions.
  * reduce memory usgae of `palantir.presults.compute_gene_trends`
- 
- ### Version 1.3.1
  * removed seaborn dependency
+ * refactor `run_diffusion_maps` to split out `compute_kernel` and `diffusion_maps_from_kernel`
 
  ### Version 1.3.0
 


### PR DESCRIPTION
## Refactor `run_diffusion_maps` to Modularize Kernel Computation and Eigen Decomposition

This commit separates the functionality of `run_diffusion_maps` into two
distinct sub-functions: `compute_kernel` handles the adaptive anisotropic
kernel calculation, while `diffusion_maps_from_kernel` performs the eigen
decomposition for the diffusion maps.