### PR TITLE
drop `tables` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,11 @@ ____
 
 Release Notes
 -------------
- ### Version 1.3.2
+ ### Version 1.3.1
  * implemented `palantir.plot.plot_stats` to plot arbitray cell-wise statistics as x-/y-positions.
  * reduce memory usgae of `palantir.presults.compute_gene_trends`
- 
- ### Version 1.3.1
  * removed seaborn dependency
+ * refactor `run_diffusion_maps` to split out `compute_kernel` and `diffusion_maps_from_kernel`
 
  ### Version 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Release Notes
  * reduce memory usgae of `palantir.presults.compute_gene_trends`
  * removed seaborn dependency
  * refactor `run_diffusion_maps` to split out `compute_kernel` and `diffusion_maps_from_kernel`
+ * remove unused dependency `tables`
 
  ### Version 1.3.0
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         "joblib",
         "fcsparser>=0.1.2",
         "leidenalg>=0.9.1",
-        "tables>=3.4.2",
         "Cython",
         "cmake",
         "matplotlib>=2.2.2",

--- a/src/palantir/version.py
+++ b/src/palantir/version.py
@@ -1,3 +1,3 @@
-__version__ = "1.3.2"
+__version__ = "1.3.1"
 __author__ = "Palantir development team"
 __author_email__ = "manu.talanki@gmail.com"


### PR DESCRIPTION
Hi @ManuSetty,

This PR addresses two specific issues:

1. **Removal of Unused `tables` Dependency**: The `tables` package does not seem to be used within the codebase, and it creates installation difficulties on Mac M1. By eliminating this dependency, we alleviate issue [#122](https://github.com/dpeerlab/Palantir/issues/122).

2. **Version Correction in `src/palantir/version.py`**: The version specified was incorrectly set to 1.3.2. This PR updates it to the accurate version, 1.3.1.